### PR TITLE
Fix incompatibility with `pycryptodome`

### DIFF
--- a/PyInstaller/archive/pyz_crypto.py
+++ b/PyInstaller/archive/pyz_crypto.py
@@ -61,4 +61,4 @@ class PyiBlockCipher(object):
         # The 'BlockAlgo' class is stateful, this factory method is used to
         # re-initialize the block cipher class with each call to encrypt() and
         # decrypt().
-        return self._aesmod.new(self.key, self._aesmod.MODE_CFB, iv)
+        return self._aesmod.new(self.key.encode(), self._aesmod.MODE_CFB, iv)


### PR DESCRIPTION
The `pycryptodome` library is a replacement for the (apparently abandoned) `pycrypto` library. It is a bit more picky concerning the `key` type as it isn't accepting `str` anymore and requires a byte array to be passed to the underlying C function. This is fixed by simply calling encode on the string. This change doesn't break compatibility with the old `pycrypto` library.